### PR TITLE
feat: add O keybinding to open current page in system handler (gt)

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -107,6 +107,7 @@ the list footer shows cache occupancy and full-text index progress.
 | `h` | go back in link history |
 | `b` | back to list |
 | `e` | enter edit mode |
+| `O` | open page source file in system default handler (e.g. GToolkit) |
 | `esc` | back to list |
 | `q` | quit |
 

--- a/lepiter-tui/src/main.rs
+++ b/lepiter-tui/src/main.rs
@@ -291,6 +291,22 @@ impl App {
         self.mode = Mode::Page;
     }
 
+    fn open_in_gt(&mut self) {
+        let Some(page_id) = self.opened.as_ref() else {
+            self.status = "no page loaded".to_string();
+            return;
+        };
+        let Some(meta) = self.index.pages.get(page_id) else {
+            self.status = "page not found".to_string();
+            return;
+        };
+        let path = meta.path.display().to_string();
+        match open_with_system(&path) {
+            Ok(()) => self.status = format!("opened in gt: {path}"),
+            Err(err) => self.status = format!("failed to open in gt: {err:#}"),
+        }
+    }
+
     fn refresh_after_edit(&mut self, id: &str) {
         if let Ok(page) = self.index.load_page(id) {
             insert_lru(
@@ -1455,6 +1471,11 @@ fn run_app(terminal: &mut DefaultTerminal, mut app: App) -> Result<()> {
             KeyCode::Char('h') => {
                 if app.mode == Mode::Page {
                     app.back_in_history();
+                }
+            }
+            KeyCode::Char('O') => {
+                if app.mode == Mode::Page {
+                    app.open_in_gt();
                 }
             }
             KeyCode::Tab => {


### PR DESCRIPTION
## What

Adds an `O` keybinding in page mode that opens the current page's `.lepiter` source file with the system default file handler.

On systems where GToolkit is installed and registered as the handler for `.lepiter` files, this opens the page directly in GT. On other systems, the OS will prompt or use whatever app handles `.lepiter` files.

## Why

Closes #17 (page-level). Some snippet types — `pharoRewrite`, complex Pharo code, etc. — cannot be rendered by lepiter-cli and require GToolkit as the authoritative viewer. This gives a one-key escape hatch to jump to GT.

Snippet-level navigation (opening a specific snippet inside GT) would require knowledge of GT's internal navigation URL or IPC API, which is left for a follow-up.

## Changes

- `App::open_in_gt()`: gets current page meta, calls `open_with_system` on the `.lepiter` file path, reports success/failure in the status bar
- `O` keybinding in page mode dispatches to `open_in_gt()`
- `docs/tui.md`: adds `O` row to the page-mode keybindings table

---
_Opened by the cyberwitchery heartbeat agent (Claude). Veit has not reviewed this yet._