### PR TITLE
add cargo-deny for license and advisory checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,22 @@ jobs:
       - name: Coverage (lepiter-core >= 75% lines)
         run: cargo llvm-cov --package lepiter-core --all-features --fail-under-lines 75 --summary-only
 
+  deny:
+    name: Deny
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+
+      - name: cargo-deny
+        run: cargo deny check
+
   unsafe-gate:
     name: Unsafe Gate
     runs-on: ubuntu-latest
@@ -114,7 +130,7 @@ jobs:
   success:
     name: Success
     if: always()
-    needs: [lint, docs, snippet-matrix, tests-and-coverage, unsafe-gate]
+    needs: [lint, docs, snippet-matrix, tests-and-coverage, deny, unsafe-gate]
     runs-on: ubuntu-latest
     steps:
       - name: Check results

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,23 @@
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "BSD-2-Clause",
+    "ISC",
+    "0BSD",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,9 @@
 [advisories]
-ignore = []
+ignore = [
+    # paste is unmaintained but pulled in transitively by ratatui's dependency
+    # tree. No security impact and no drop-in replacement available yet.
+    "RUSTSEC-2024-0436",
+]
 
 [licenses]
 allow = [
@@ -9,6 +13,7 @@ allow = [
     "BSD-2-Clause",
     "ISC",
     "0BSD",
+    "Zlib",
     "Unicode-3.0",
     "Unicode-DFS-2016",
 ]


### PR DESCRIPTION
## What

Adds a `deny.toml` and a `deny` CI job that runs `cargo deny check`. Uses the same license allowlist and source restrictions as other cyberwitchery repos.

## Why

Catches license violations, known advisories, and unexpected crate sources in CI. Consistent with the setup in contextual-encoder, sbom-diff, unsafe-budget, and dd.

---
_Opened by the cyberwitchery heartbeat agent (Claude). Veit has not reviewed this yet._