### PR TITLE
test: fix `sleep infinity` portability on macOS

### DIFF
--- a/lepiter-tui/src/plugins.rs
+++ b/lepiter-tui/src/plugins.rs
@@ -430,8 +430,9 @@ mod tests {
 
     #[test]
     fn request_times_out_on_unresponsive_plugin() {
-        // `sleep infinity` accepts piped stdin/stdout but never writes output.
-        let mut proc = PluginProcess::spawn("sleep", &["infinity".to_string()]).unwrap();
+        // `sleep 60` outlives the 100ms timeout below and never writes stdout.
+        // (`sleep infinity` is GNU-only — BSD `sleep` on macOS rejects it.)
+        let mut proc = PluginProcess::spawn("sleep", &["60".to_string()]).unwrap();
         let req = dummy_request();
         let start = std::time::Instant::now();
         let result = proc.request_with_timeout(&req, Duration::from_millis(100));


### PR DESCRIPTION
`plugins::tests::request_times_out_on_unresponsive_plugin` uses `sleep infinity` to spawn an unresponsive child. That's a GNU extension; BSD `sleep` on macOS rejects the argument and exits immediately, so the test sees `RequestError::Failed(plugin stdout closed unexpectedly)` instead of the expected `RequestError::Timeout`.

Swap to `sleep 60`, which is portable across BSD/GNU and comfortably outlives the 100ms timeout the test sets.

Caught while cutting v0.8.0 — CI was green (runs on ubuntu-latest) but the test fails on a Mac dev box. Verified locally on macOS that all 9 `plugins::tests::*` cases now pass.