### PR TITLE
ci: switch from Swatinem/rust-cache to kache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-lint
 
       - name: Rustfmt
         run: cargo fmt --all -- --check
@@ -42,7 +44,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-docs
 
       - name: Build docs (warnings denied)
         env:
@@ -60,7 +64,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-snippet-matrix
 
       - name: Refresh snippet matrix docs
         run: ./scripts/refresh_snippet_matrix.sh
@@ -84,7 +90,9 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-tests-and-coverage
 
       - name: Run tests
         run: cargo test --workspace
@@ -119,7 +127,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-unsafe-gate
 
       - name: Install unsafe-budget
         run: cargo install unsafe-budget


### PR DESCRIPTION
Same change as the netbox.rs / netform / sbom-diff / infrahub-erd / contextual-encoder PRs. Per-rustc content-hashed cache instead of target-dir snapshot.