### PR TITLE
ci: revert kache, restore Swatinem (small-repo overhead)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo
-        uses: kunobi-ninja/kache-action@v1
-        with:
-          cache-key-prefix: kache-lint
+        uses: Swatinem/rust-cache@v2
 
       - name: Rustfmt
         run: cargo fmt --all -- --check
@@ -44,9 +42,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: kunobi-ninja/kache-action@v1
-        with:
-          cache-key-prefix: kache-docs
+        uses: Swatinem/rust-cache@v2
 
       - name: Build docs (warnings denied)
         env:
@@ -64,9 +60,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: kunobi-ninja/kache-action@v1
-        with:
-          cache-key-prefix: kache-snippet-matrix
+        uses: Swatinem/rust-cache@v2
 
       - name: Refresh snippet matrix docs
         run: ./scripts/refresh_snippet_matrix.sh
@@ -90,9 +84,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Cache cargo
-        uses: kunobi-ninja/kache-action@v1
-        with:
-          cache-key-prefix: kache-tests-and-coverage
+        uses: Swatinem/rust-cache@v2
 
       - name: Run tests
         run: cargo test --workspace
@@ -127,9 +119,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: kunobi-ninja/kache-action@v1
-        with:
-          cache-key-prefix: kache-unsafe-gate
+        uses: Swatinem/rust-cache@v2
 
       - name: Install unsafe-budget
         run: cargo install unsafe-budget


### PR DESCRIPTION
Reverts PR #80.

PR #80 switched this repo from Swatinem/rust-cache to kache as part of the org-wide rollout that followed netbox.rs PR #28. Empirical warm-rerun measurements after merging across all 7 cyberwitchery repos showed:

| Repo | Swatinem warm | Kache warm |
|---|---|---|
| netform | 14.49s | 5.80s (2.5×) |
| sbom-diff | 24.04s | 9.61s (2.5×) |
| infrahub-erd | 27.27s | 6.81s (4×) |
| nautobot.rs | 4m 08s | 40.38s (6×) |
| infrahub.rs | 1m 25s | 1m 11s (1.2×) |
| **lepiter-cli** | **4.98s** | **6.59s (regression)** |

Kache's per-rustc `RUSTC_WRAPPER` lookup adds fixed overhead per compilation. On a workspace where the test compile is already only ~5 seconds, that overhead exceeds the savings. Reverting just this repo.