### PR TITLE
fix(core): avoid panic in extract_uuid_like on non-ASCII input

### DIFF
--- a/lepiter-core/src/util.rs
+++ b/lepiter-core/src/util.rs
@@ -148,7 +148,12 @@ pub(crate) fn extract_uuid_like(input: &str) -> Option<&str> {
     }
 
     for i in 0..=bytes.len() - 36 {
-        let cand = &input[i..i + 36];
+        // `i` walks byte offsets, so it can land inside a multi-byte UTF-8
+        // char; `get` yields None there instead of panicking. A UUID is pure
+        // ASCII, so a non-boundary slice can never be a real candidate.
+        let Some(cand) = input.get(i..i + 36) else {
+            continue;
+        };
         let ok = cand.chars().enumerate().all(|(idx, c)| match idx {
             8 | 13 | 18 | 23 => c == '-',
             _ => c.is_ascii_hexdigit(),


### PR DESCRIPTION
## Problem

`extract_uuid_like` (`lepiter-core/src/util.rs`) walks **byte** offsets but slices the original `&str` with `&input[i..i + 36]`. When `i` or `i + 36` lands inside a multi-byte UTF-8 char, that slice panics.

The function is called from `classify_link_target` on link targets / titles, so any page whose title or `[[…]]` link contains a non-ASCII char (e.g. an em-dash `—`) crashes link classification — which takes down `export`:

```
thread 'main' panicked at lepiter-core/src/util.rs:151:26:
start byte index 18 is not a char boundary; it is inside '—' (bytes 17..20) of
`Molding CSV data — actions, queries and visualizations`
```

The input is valid; the function's byte-indexed slicing of a `&str` is the bug.

## Fix

Slice via `input.get(i..i + 36)` and skip non-char-boundary offsets. A UUID is pure ASCII, so a non-boundary slice can never be a real candidate, and no valid match is lost.

## Verification

With this fix a full `export` of the gt-book fixture (`./lepiter`) completes all 633 pages instead of panicking partway. Surfaced while verifying #114 end-to-end (the export → import roundtrip needs export not to crash).