### PR TITLE
tests: a unique temp directory per test, from tempfile rather than a timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.19",
  "walkdir",
 ]

--- a/lepiter-core/Cargo.toml
+++ b/lepiter-core/Cargo.toml
@@ -18,3 +18,4 @@ walkdir.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true
+tempfile.workspace = true

--- a/lepiter-core/src/index.rs
+++ b/lepiter-core/src/index.rs
@@ -784,14 +784,16 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::fs;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
+    /// a directory no other test shares. `tempfile` picks the name: a timestamp
+    /// cannot, because `SystemTime::now` ticks at microsecond granularity here, so
+    /// two tests in the same process stamp the same value and share a directory.
     fn temp_dir_path(name: &str) -> PathBuf {
-        let ts = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("time")
-            .as_nanos();
-        std::env::temp_dir().join(format!("lepiter-core-{name}-{ts}"))
+        tempfile::Builder::new()
+            .prefix(&format!("lepiter-core-{name}-"))
+            .tempdir()
+            .expect("temp dir")
+            .keep()
     }
 
     fn make_kb_on_disk(pages: &[(&str, &str, &[&str], &str)]) -> (PathBuf, KnowledgeBaseIndex) {

--- a/lepiter-core/src/model.rs
+++ b/lepiter-core/src/model.rs
@@ -236,13 +236,15 @@ mod tests {
     use super::*;
     use std::fs;
 
+    /// a directory no other test shares. `tempfile` picks the name: a timestamp
+    /// cannot, because `SystemTime::now` ticks at microsecond granularity here, so
+    /// two tests in the same process stamp the same value and share a directory.
     fn temp_dir_path(name: &str) -> PathBuf {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let ts = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("time")
-            .as_nanos();
-        std::env::temp_dir().join(format!("lepiter-core-{name}-{ts}"))
+        tempfile::Builder::new()
+            .prefix(&format!("lepiter-core-{name}-"))
+            .tempdir()
+            .expect("temp dir")
+            .keep()
     }
 
     #[test]

--- a/lepiter-core/src/parse.rs
+++ b/lepiter-core/src/parse.rs
@@ -578,14 +578,18 @@ mod tests {
     use serde_json::json;
     use std::fs;
     use std::path::PathBuf;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
+    /// a file path in a directory no other test shares. `tempfile` picks the
+    /// directory name: a timestamp cannot, because `SystemTime::now` ticks at
+    /// microsecond granularity here, so two tests in the same process stamp the
+    /// same value and collide.
     fn temp_file_path(name: &str) -> PathBuf {
-        let ts = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("time")
-            .as_nanos();
-        std::env::temp_dir().join(format!("lepiter-core-{name}-{ts}.lepiter"))
+        tempfile::Builder::new()
+            .prefix("lepiter-core-")
+            .tempdir()
+            .expect("temp dir")
+            .keep()
+            .join(format!("{name}.lepiter"))
     }
 
     #[test]

--- a/lepiter-tui/src/cli/check.rs
+++ b/lepiter-tui/src/cli/check.rs
@@ -305,13 +305,14 @@ mod tests {
     use std::path::PathBuf;
 
     fn make_test_kb(pages: &[(&str, &str, &str)]) -> (std::path::PathBuf, KnowledgeBaseIndex) {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let ts = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("time")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("lepiter-check-test-{ts}"));
-        std::fs::create_dir_all(&dir).unwrap();
+        // `tempfile` picks the name: a timestamp cannot, because `SystemTime::now`
+        // ticks at microsecond granularity here, so two tests in the same process
+        // stamp the same value and share a directory.
+        let dir = tempfile::Builder::new()
+            .prefix("lepiter-check-test-")
+            .tempdir()
+            .expect("temp dir")
+            .keep();
         for (id, title, body) in pages {
             let content = serde_json::json!({
                 "uid": {"uuid": id},

--- a/lepiter-tui/src/cli/export.rs
+++ b/lepiter-tui/src/cli/export.rs
@@ -321,13 +321,14 @@ mod tests {
     }
 
     fn make_test_kb(pages: &[(&str, &str)]) -> (std::path::PathBuf, KnowledgeBaseIndex) {
-        let dir = std::env::temp_dir().join(format!(
-            "lepiter-export-test-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        // `tempfile` picks the name: a timestamp cannot, because `SystemTime::now`
+        // ticks at microsecond granularity here, so two tests in the same process
+        // stamp the same value and share a directory.
+        let dir = tempfile::Builder::new()
+            .prefix("lepiter-export-test-")
+            .tempdir()
+            .expect("temp dir")
+            .keep();
         std::fs::create_dir_all(&dir).unwrap();
 
         for (id, title) in pages {

--- a/lepiter-tui/src/cli/import.rs
+++ b/lepiter-tui/src/cli/import.rs
@@ -744,13 +744,14 @@ mod tests {
 
     #[test]
     fn import_skips_traversal_id_without_writing_outside_kb() {
-        let dir = std::env::temp_dir().join(format!(
-            "lepiter-import-traversal-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        // `tempfile` picks the name: a timestamp cannot, because `SystemTime::now`
+        // ticks at microsecond granularity here, so two tests in the same process
+        // stamp the same value and share a directory.
+        let dir = tempfile::Builder::new()
+            .prefix("lepiter-import-traversal-")
+            .tempdir()
+            .expect("temp dir")
+            .keep();
         let input_dir = dir.join("input");
         let out_dir = dir.join("output");
         std::fs::create_dir_all(&input_dir).unwrap();
@@ -783,13 +784,14 @@ mod tests {
 
     #[test]
     fn import_skips_duplicate_id_keeping_first_file() {
-        let dir = std::env::temp_dir().join(format!(
-            "lepiter-import-dup-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        // `tempfile` picks the name: a timestamp cannot, because `SystemTime::now`
+        // ticks at microsecond granularity here, so two tests in the same process
+        // stamp the same value and share a directory.
+        let dir = tempfile::Builder::new()
+            .prefix("lepiter-import-dup-")
+            .tempdir()
+            .expect("temp dir")
+            .keep();
         let input_dir = dir.join("input");
         let out_dir = dir.join("output");
         std::fs::create_dir_all(&input_dir).unwrap();
@@ -1412,13 +1414,14 @@ mod tests {
 
     #[test]
     fn end_to_end_import() {
-        let dir = std::env::temp_dir().join(format!(
-            "lepiter-import-test-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        // `tempfile` picks the name: a timestamp cannot, because `SystemTime::now`
+        // ticks at microsecond granularity here, so two tests in the same process
+        // stamp the same value and share a directory.
+        let dir = tempfile::Builder::new()
+            .prefix("lepiter-import-test-")
+            .tempdir()
+            .expect("temp dir")
+            .keep();
         let out_dir = dir.join("output");
         let input_dir = dir.join("input");
         std::fs::create_dir_all(&input_dir).unwrap();

--- a/lepiter-tui/src/cli/info.rs
+++ b/lepiter-tui/src/cli/info.rs
@@ -352,13 +352,14 @@ mod tests {
     fn make_test_kb(
         pages: &[(&str, &str, &str)],
     ) -> (std::path::PathBuf, lepiter_core::KnowledgeBaseIndex) {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let ts = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("time")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("lepiter-tui-test-{ts}"));
-        std::fs::create_dir_all(&dir).unwrap();
+        // `tempfile` picks the name: a timestamp cannot, because `SystemTime::now`
+        // ticks at microsecond granularity here, so two tests in the same process
+        // stamp the same value and share a directory.
+        let dir = tempfile::Builder::new()
+            .prefix("lepiter-tui-test-")
+            .tempdir()
+            .expect("temp dir")
+            .keep();
         for (id, title, body) in pages {
             let content = serde_json::json!({
                 "uid": {"uuid": id},

--- a/lepiter-tui/src/cli/list.rs
+++ b/lepiter-tui/src/cli/list.rs
@@ -75,13 +75,14 @@ mod tests {
     use lepiter_core::KnowledgeBase;
 
     fn make_test_kb(pages: &[(&str, &str, &str)]) -> (std::path::PathBuf, KnowledgeBaseIndex) {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let ts = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("time")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("lepiter-list-test-{ts}"));
-        std::fs::create_dir_all(&dir).unwrap();
+        // `tempfile` picks the name: a timestamp cannot, because `SystemTime::now`
+        // ticks at microsecond granularity here, so two tests in the same process
+        // stamp the same value and share a directory.
+        let dir = tempfile::Builder::new()
+            .prefix("lepiter-list-test-")
+            .tempdir()
+            .expect("temp dir")
+            .keep();
         for (id, title, body) in pages {
             let content = serde_json::json!({
                 "uid": {"uuid": id},

--- a/lepiter-tui/src/cli/mod.rs
+++ b/lepiter-tui/src/cli/mod.rs
@@ -248,14 +248,14 @@ mod tests {
     // --- read_kb_properties ---
 
     fn props_temp_dir(tag: &str) -> PathBuf {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let ts = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("lepiter-props-{tag}-{ts}"));
-        fs::create_dir_all(&dir).unwrap();
-        dir
+        // `tempfile` picks the name: a timestamp cannot, because `SystemTime::now`
+        // ticks at microsecond granularity here, so two tests in the same process
+        // stamp the same value and share a directory.
+        tempfile::Builder::new()
+            .prefix(&format!("lepiter-props-{tag}-"))
+            .tempdir()
+            .expect("temp dir")
+            .keep()
     }
 
     #[test]

--- a/lepiter-tui/src/cli/search.rs
+++ b/lepiter-tui/src/cli/search.rs
@@ -200,13 +200,14 @@ mod tests {
     fn make_test_kb(
         pages: &[(&str, &str, &[&str], &str)],
     ) -> (std::path::PathBuf, KnowledgeBaseIndex) {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let ts = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("time")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("lepiter-search-test-{ts}"));
-        std::fs::create_dir_all(&dir).unwrap();
+        // `tempfile` picks the name: a timestamp cannot, because `SystemTime::now`
+        // ticks at microsecond granularity here, so two tests in the same process
+        // stamp the same value and share a directory.
+        let dir = tempfile::Builder::new()
+            .prefix("lepiter-search-test-")
+            .tempdir()
+            .expect("temp dir")
+            .keep();
         for (id, title, tags, body) in pages {
             let tags_json: Vec<serde_json::Value> =
                 tags.iter().map(|t| serde_json::json!(t)).collect();

--- a/lepiter-tui/tests/cli.rs
+++ b/lepiter-tui/tests/cli.rs
@@ -38,14 +38,16 @@ fn fixtures_path_str() -> String {
     fixtures_dir().display().to_string()
 }
 
+/// a directory no other test shares. `tempfile` picks the name: a timestamp
+/// cannot, because `SystemTime::now` ticks at microsecond granularity here, so
+/// two tests in the same process stamp the same value and collide. unlike the
+/// old helper this creates the directory, which both callers went on to do.
 fn unique_temp(tag: &str) -> PathBuf {
-    std::env::temp_dir().join(format!(
-        "lepiter-cli-{tag}-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ))
+    tempfile::Builder::new()
+        .prefix(&format!("lepiter-cli-{tag}-"))
+        .tempdir()
+        .expect("temp dir")
+        .keep()
 }
 
 /// a temp kb holding one page, one text snippet per entry.
@@ -1381,15 +1383,11 @@ mod check_properties {
     use std::path::Path;
 
     fn temp_kb(tag: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "lepiter-cli-props-{tag}-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        dir
+        tempfile::Builder::new()
+            .prefix(&format!("lepiter-cli-props-{tag}-"))
+            .tempdir()
+            .expect("temp dir")
+            .keep()
     }
 
     fn write_page(dir: &Path, id: &str, title: &str, body: &str) {


### PR DESCRIPTION
`cli::list::tests::list_tsv_contains_title_and_id` fails intermittently on `main`. eight test-helper functions built their directory name from a timestamp:

```rust
let ts = SystemTime::now().duration_since(UNIX_EPOCH).expect("time").as_nanos();
let dir = std::env::temp_dir().join(format!("lepiter-list-test-{ts}"));
```

`as_nanos()` is not nanosecond-resolution. measured on this machine, 12 threads sampling 200 times each:

```
samples=2400 unique=85 collisions=2315
smallest nonzero tick observed = 1000 ns
```

granularity is 1 microsecond, so the value's last three digits are always zero and any two calls inside the same microsecond produce a byte-identical name. cargo runs tests as threads of one process, so `make_test_kb` is called from many of them at once: two colliding tests share a directory and each sees the other's `.lepiter` pages. `list_tsv_contains_title_and_id` writes one page and asserts `fields[0] == "Alpha"`, so it fails the moment a neighbour's page sorts ahead of its own.

## measured, before and after

`cargo test -p lepiter-cli --bin lepiter-cli`, repeated:

| | result |
|---|---|
| `main`, parallel, 6 runs | **5 failed**, 1 passed |
| `main`, `--test-threads=1`, 3 runs | 3 passed |
| this branch, parallel, 8 runs | **8 passed** |

serial passing is the tell: the bug is contention for one path, not the assertion.

## the change

each helper keeps its signature and returns a `PathBuf`; only the name now comes from `tempfile`, which creates the directory with `O_EXCL` and retries on collision. `keep()` (not the deprecated `into_path()`) hands back the path with auto-delete off, so the existing `remove_dir_all` cleanup in the tests keeps working exactly as before.

that is the reason this is ~90 lines rather than ~400: switching the helpers to return `TempDir` would have been the more thorough fix, giving cleanup on panic too, but it would have rewritten **164** `remove_dir_all` call sites and every `let (dir, index) = make_test_kb(..)` binding — and it would have introduced a fresh trap, since `let (_, index)` drops a `TempDir` immediately while `let (_dir, index)` does not. the leak on panic is pre-existing and orthogonal; this PR fixes the race only.

sites: `list.rs`, `check.rs`, `search.rs`, `info.rs`, `export.rs`, `mod.rs`, `import.rs` (3 inline), `tests/cli.rs` (2), and `lepiter-core`'s `index.rs`, `model.rs`, `parse.rs`. `grep -rn 'env::temp_dir()' --include='*.rs'` now returns nothing.

one behaviour note: `tests/cli.rs`'s `unique_temp` previously returned a path *without* creating it. it creates it now. both callers went straight on to create it themselves, and `create_dir_all` is idempotent, so nothing depends on the old semantics — the doc comment says so.

`lepiter-core` gains `tempfile` as a dev-dependency; it was already a workspace dependency and a regular dependency of `lepiter-tui`, so no new package enters `Cargo.lock`.

## verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace` (445 + 103 + 203 + 17 + 3 + 2 + 1, all pass) and `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` are clean.

no changelog entry: test-only, no user-visible change. this matches #143, the last test-only fix here.

related: alembic#358 fixes the same mechanism in `alembic-adapter-infrahub`, which alembic#340 skipped on the grounds that nanos-plus-pid was already sufficient.
